### PR TITLE
Removed Firebase and Google Play Services dependencies from library project that aren't mandatory

### DIFF
--- a/LocalyticsXamarin/LocalyticsXamarin.Android/LocalyticsXamarin.Android.csproj
+++ b/LocalyticsXamarin/LocalyticsXamarin.Android/LocalyticsXamarin.Android.csproj
@@ -58,31 +58,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
-    <Reference Include="Xamarin.GooglePlayServices.Basement">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Basement.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Basement.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Tasks">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Tasks.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Firebase.Common">
-      <HintPath>..\packages\Xamarin.Firebase.Common.60.1142.1\lib\MonoAndroid80\Xamarin.Firebase.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Firebase.Iid">
-      <HintPath>..\packages\Xamarin.Firebase.Iid.60.1142.1\lib\MonoAndroid80\Xamarin.Firebase.Iid.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Firebase.Messaging">
-      <HintPath>..\packages\Xamarin.Firebase.Messaging.60.1142.1\lib\MonoAndroid80\Xamarin.Firebase.Messaging.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Firebase.Messaging">
-      <HintPath>..\packages\Xamarin.Firebase.Messaging.60.1142.1\lib\MonoAndroid80\Xamarin.Firebase.Messaging.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Base">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Base.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Base.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Location">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Location.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Location.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Xamarin.AndroidX.Activity, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xamarin.AndroidX.Activity.1.2.0.1\lib\monoandroid90\Xamarin.AndroidX.Activity.dll</HintPath>
     </Reference>
@@ -235,13 +210,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.targets" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.targets')" />
-  <Import Project="..\packages\Xamarin.GooglePlayServices.Basement.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Basement.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Basement.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Basement.targets')" />
-  <Import Project="..\packages\Xamarin.GooglePlayServices.Tasks.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Tasks.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Tasks.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Tasks.targets')" />
-  <Import Project="..\packages\Xamarin.Firebase.Common.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Common.targets" Condition="Exists('..\packages\Xamarin.Firebase.Common.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Common.targets')" />
-  <Import Project="..\packages\Xamarin.Firebase.Iid.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Iid.targets" Condition="Exists('..\packages\Xamarin.Firebase.Iid.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Iid.targets')" />
-  <Import Project="..\packages\Xamarin.Firebase.Messaging.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Messaging.targets" Condition="Exists('..\packages\Xamarin.Firebase.Messaging.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Messaging.targets')" />
   <Import Project="..\packages\Xamarin.Build.Download.0.4.11\build\Xamarin.Build.Download.targets" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.11\build\Xamarin.Build.Download.targets')" />
-  <Import Project="..\packages\Xamarin.GooglePlayServices.Base.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Base.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Base.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Base.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Activity.1.2.0.1\build\monoandroid9.0\Xamarin.AndroidX.Activity.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Activity.1.2.0.1\build\monoandroid9.0\Xamarin.AndroidX.Activity.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Annotation.1.1.0.9\build\monoandroid9.0\Xamarin.AndroidX.Annotation.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Annotation.1.1.0.9\build\monoandroid9.0\Xamarin.AndroidX.Annotation.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Annotation.Experimental.1.0.0.9\build\monoandroid9.0\Xamarin.AndroidX.Annotation.Experimental.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Annotation.Experimental.1.0.0.9\build\monoandroid9.0\Xamarin.AndroidX.Annotation.Experimental.targets')" />

--- a/LocalyticsXamarin/LocalyticsXamarin.Android/packages.config
+++ b/LocalyticsXamarin/LocalyticsXamarin.Android/packages.config
@@ -43,29 +43,5 @@
   <package id="Xamarin.AndroidX.ViewPager" version="1.0.0.7" targetFramework="monoandroid11.0" requireReinstallation="true" />
   <package id="Xamarin.AndroidX.Work.Runtime" version="2.5.0.1" targetFramework="monoandroid11.0" requireReinstallation="true" />
   <package id="Xamarin.Build.Download" version="0.10.0" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Annotations" version="116.0.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Firebase.Common" version="119.5.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Firebase.Components" version="116.1.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Firebase.Datatransport" version="117.0.10" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Firebase.Encoders" version="116.1.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Firebase.Encoders.JSON" version="117.1.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Firebase.Iid" version="121.0.1" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Firebase.Iid.Interop" version="117.0.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Firebase.Installations" version="116.3.5" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Firebase.Installations.InterOp" version="116.0.1" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Firebase.Measurement.Connector" version="118.0.2" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Firebase.Messaging" version="121.0.1" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Google.Android.DataTransport.TransportApi" version="2.2.1" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Google.Android.DataTransport.TransportBackendCct" version="2.3.3" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Google.Android.DataTransport.TransportRuntime" version="2.2.5" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.Google.Dagger" version="2.27.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
   <package id="Xamarin.Google.Guava.ListenableFuture" version="1.0.0.2" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.GooglePlayServices.Base" version="117.6.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.GooglePlayServices.Basement" version="117.6.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.GooglePlayServices.CloudMessaging" version="116.0.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.GooglePlayServices.Measurement.Base" version="118.0.2" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.GooglePlayServices.Measurement.Sdk.Api" version="118.0.2" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.GooglePlayServices.Stats" version="117.0.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.GooglePlayServices.Tasks" version="117.2.1" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.JavaX.Inject" version="1.0.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
 </packages>


### PR DESCRIPTION
Ideally, we don't want to take on these dependencies if we don't need these feature of Localytics. Making them optional like the native library